### PR TITLE
CreateExpressMiddleware: Send 404 code for disabled feature

### DIFF
--- a/src/create-express-middleware.js
+++ b/src/create-express-middleware.js
@@ -5,9 +5,6 @@ import { isActiveFeatureName } from './is-active-feature-name';
 import { mergeFeatureNames } from './merge-feature-names';
 import { getQueryFeatureNames } from './get-query-feature-names';
 
-const setStatus = (res, isActiveFeatureName) =>
-  isActiveFeatureName ? res.status(200) : res.status(404).send();
-
 // ({ features: [...String] }, requiredFeature: String, methods?: Object) => (req, res, next) => void
 export const createExpressMiddleware = curry(
   ({ features }, requiredFeature, methods) => (req, res, next) => {
@@ -17,7 +14,9 @@ export const createExpressMiddleware = curry(
       features,
       getQueryFeatureNames(query)
     );
-    setStatus(res, isActiveFeatureName(requiredFeature, updatedFeatures));
+
+    if (!isActiveFeatureName(requiredFeature, updatedFeatures))
+      res.status(404).send();
 
     const handler = methods[req.method.toLowerCase()];
     if (handler !== undefined && typeof handler === 'function') {

--- a/src/create-express-middleware.js
+++ b/src/create-express-middleware.js
@@ -6,7 +6,7 @@ import { mergeFeatureNames } from './merge-feature-names';
 import { getQueryFeatureNames } from './get-query-feature-names';
 
 const setStatus = (res, isActiveFeatureName) =>
-  isActiveFeatureName ? res.status(200) : res.status(404);
+  isActiveFeatureName ? res.status(200) : res.status(404).send();
 
 // ({ features: [...String] }, requiredFeature: String, methods?: Object) => (req, res, next) => void
 export const createExpressMiddleware = curry(

--- a/src/create-express-middleware.js
+++ b/src/create-express-middleware.js
@@ -15,8 +15,9 @@ export const createExpressMiddleware = curry(
       getQueryFeatureNames(query)
     );
 
-    if (!isActiveFeatureName(requiredFeature, updatedFeatures))
-      res.status(404).send();
+    if (!isActiveFeatureName(requiredFeature, updatedFeatures)) {
+      return res.status(404).send();
+    }
 
     const handler = methods[req.method.toLowerCase()];
     if (handler !== undefined && typeof handler === 'function') {

--- a/test/integration/create-express-middleware.js
+++ b/test/integration/create-express-middleware.js
@@ -34,6 +34,7 @@ describe('createExpressMiddleware()', async should => {
     const features = ['posts', 'bar', 'foo'];
     const handler = createExpressMiddleware({ features }, 'help', {
       get: (req, res) => {
+        res.status(400);
         res.send();
       }
     });


### PR DESCRIPTION
I'm not sure if this is the correct way to handle it, but I think we need to send the 404 status after setting it. Otherwise the status can be overwritten in the handler. 